### PR TITLE
Исправил обрезание красной компоненты цвета

### DIFF
--- a/firmware/GyverStringOffline_v1.2/runningText.ino
+++ b/firmware/GyverStringOffline_v1.2/runningText.ino
@@ -66,7 +66,7 @@ uint32_t setColor(int index) {
   }
 }
 
-void drawLetter(int index, uint8_t letter, int offset, int letterColor) {
+void drawLetter(int index, uint8_t letter, int offset, uint32_t letterColor) {
   int start_pos = 0, finish_pos = LET_WIDTH;
 
   if (offset < -LET_WIDTH || offset > WIDTH) return;


### PR DESCRIPTION
В определении функции void drawLetter(int index, uint8_t letter, int offset, int letterColor)
letterColor двухбайтный, соответственно, когда в него передаёшь красный цвет 0xff0000, обрезается всё кроме младших двух байтов. В случае красного цвета, цвет обрезается до 0x0000, т.е. до черного. 